### PR TITLE
TimeOfImpact loop fixes

### DIFF
--- a/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
+++ b/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
@@ -490,10 +490,6 @@ class SeparationFunction {
 
     switch (m_type) {
       case POINTS: {
-        Rot.mulTransUnsafe(xfa.q, m_axis, axisA);
-        Rot.mulTransUnsafe(xfb.q, m_axis.negateLocal(), axisB);
-        m_axis.negateLocal();
-
         localPointA.set(m_proxyA.getVertex(indexA));
         localPointB.set(m_proxyB.getVertex(indexB));
 
@@ -507,9 +503,6 @@ class SeparationFunction {
         Rot.mulToOutUnsafe(xfa.q, m_axis, normal);
         Transform.mulToOutUnsafe(xfa, m_localPoint, pointA);
 
-        Rot.mulTransUnsafe(xfb.q, normal.negateLocal(), axisB);
-        normal.negateLocal();
-
         localPointB.set(m_proxyB.getVertex(indexB));
         Transform.mulToOutUnsafe(xfb, localPointB, pointB);
         float separation = Vec2.dot(pointB.subLocal(pointA), normal);
@@ -518,9 +511,6 @@ class SeparationFunction {
       case FACE_B: {
         Rot.mulToOutUnsafe(xfb.q, m_axis, normal);
         Transform.mulToOutUnsafe(xfb, m_localPoint, pointB);
-
-        Rot.mulTransUnsafe(xfa.q, normal.negateLocal(), axisA);
-        normal.negateLocal();
 
         localPointA.set(m_proxyA.getVertex(indexA));
         Transform.mulToOutUnsafe(xfa, localPointA, pointA);

--- a/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
+++ b/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
@@ -35,7 +35,7 @@ import org.jbox2d.pooling.IWorldPool;
 
 /**
  * Class used for computing the time of impact. This class should not be constructed usually, just
- * retrieve from the {@link SingletonPool#getTOI()}.
+ * retrieve from the {@link IWorldPool#getTimeOfImpact()}.
  * 
  * @author daniel
  */

--- a/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
+++ b/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
@@ -40,7 +40,7 @@ import org.jbox2d.pooling.IWorldPool;
  * @author daniel
  */
 public class TimeOfImpact {
-  public static final int MAX_ITERATIONS = 1000;
+  public static final int MAX_ITERATIONS = 20;
 
   public static int toiCalls = 0;
   public static int toiIters = 0;

--- a/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
+++ b/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
@@ -41,6 +41,7 @@ import org.jbox2d.pooling.IWorldPool;
  */
 public class TimeOfImpact {
   public static final int MAX_ITERATIONS = 20;
+  public static final int MAX_ROOT_ITERATIONS = 50;
 
   public static int toiCalls = 0;
   public static int toiIters = 0;
@@ -262,8 +263,7 @@ public class TimeOfImpact {
             s2 = s;
           }
 
-          // djm: whats with this? put in settings?
-          if (rootIterCount == 50) {
+          if (rootIterCount == MAX_ROOT_ITERATIONS) {
             break;
           }
         }
@@ -272,7 +272,7 @@ public class TimeOfImpact {
 
         ++pushBackIter;
 
-        if (pushBackIter == Settings.maxPolygonVertices || rootIterCount == 50) {
+        if (pushBackIter == Settings.maxPolygonVertices || rootIterCount == MAX_ROOT_ITERATIONS) {
           break;
         }
       }

--- a/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
+++ b/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
@@ -272,7 +272,7 @@ public class TimeOfImpact {
 
         ++pushBackIter;
 
-        if (pushBackIter == Settings.maxPolygonVertices) {
+        if (pushBackIter == Settings.maxPolygonVertices || rootIterCount == 50) {
           break;
         }
       }

--- a/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
+++ b/jbox2d-library/src/main/java/org/jbox2d/collision/TimeOfImpact.java
@@ -242,6 +242,9 @@ public class TimeOfImpact {
             t = 0.5f * (a1 + a2);
           }
 
+          ++rootIterCount;
+          ++toiRootIters;
+
           float s = fcn.evaluate(indexes[0], indexes[1], t);
 
           if (MathUtils.abs(s - target) < tolerance) {
@@ -258,9 +261,6 @@ public class TimeOfImpact {
             a2 = t;
             s2 = s;
           }
-
-          ++rootIterCount;
-          ++toiRootIters;
 
           // djm: whats with this? put in settings?
           if (rootIterCount == 50) {


### PR DESCRIPTION
These are some small fixes for the TimeOfImpact class. I was experiencing occasional stalls in the main loop under certain circumstances. These changes seem to fix those.

I compared the TimeOfImpact class to the latest C++ Box2D source and ported some of the changes found there.

b83f937 is not based on the Box2D source and is probably the most important change here as it prevents a whole lot of useless loop iterations under certain conditions. If the root loop is exhausted (performs 50 iterations without reaching a solution) nothing will have changed in the enclosing loop (since neither `t1` nor `t2` will have changed), so the enclosing loop will continue looping and calculating the same thing without reaching a solution.