### PR TITLE
add particle iteration handling from the C++ lib

### DIFF
--- a/jbox2d-library/src/main/java/org/jbox2d/dynamics/TimeStep.java
+++ b/jbox2d-library/src/main/java/org/jbox2d/dynamics/TimeStep.java
@@ -41,6 +41,22 @@ public class TimeStep {
 	public int velocityIterations;
 	
 	public int positionIterations;
-	
+
+	public int particleIterations;
+
 	public boolean warmStarting;
+
+	public TimeStep clone() {
+		TimeStep ts = new TimeStep();
+
+		ts.dt = dt;
+		ts.inv_dt = inv_dt;
+		ts.dtRatio = dtRatio;
+		ts.velocityIterations = velocityIterations;
+		ts.positionIterations = positionIterations;
+		ts.particleIterations = particleIterations;
+		ts.warmStarting = warmStarting;
+
+		return ts;
+	}
 }

--- a/jbox2d-library/src/main/java/org/jbox2d/dynamics/World.java
+++ b/jbox2d-library/src/main/java/org/jbox2d/dynamics/World.java
@@ -588,13 +588,26 @@ public class World {
   private final Timer tempTimer = new Timer();
 
   /**
-   * Take a time step. This performs collision detection, integration, and constraint solution.
+   * Take a time step. This performs collision detection, integration, and 
+   * constraint solution. particleIterations defaults to 1
    * 
    * @param timeStep the amount of time to simulate, this should not vary.
    * @param velocityIterations for the velocity constraint solver.
    * @param positionIterations for the position constraint solver.
    */
   public void step(float dt, int velocityIterations, int positionIterations) {
+    step(dt, velocityIterations, positionIterations, 1);
+  }
+
+  /**
+   * Take a time step. This performs collision detection, integration, and constraint solution.
+   * 
+   * @param timeStep the amount of time to simulate, this should not vary.
+   * @param velocityIterations for the velocity constraint solver.
+   * @param positionIterations for the position constraint solver.
+   * @param particleIterations for the particle solver.
+   */
+  public void step(float dt, int velocityIterations, int positionIterations, int particleIterations) {
     stepTimer.reset();
     tempTimer.reset();
     // log.debug("Starting step");
@@ -610,6 +623,7 @@ public class World {
     step.dt = dt;
     step.velocityIterations = velocityIterations;
     step.positionIterations = positionIterations;
+    step.particleIterations = particleIterations;
     if (dt > 0.0f) {
       step.inv_dt = 1.0f / dt;
     } else {

--- a/jbox2d-library/src/main/java/org/jbox2d/particle/ParticleSystem.java
+++ b/jbox2d-library/src/main/java/org/jbox2d/particle/ParticleSystem.java
@@ -683,7 +683,6 @@ public class ParticleSystem {
   }
 
   public void solve(TimeStep step) {
-    ++m_timestamp;
     if (m_count == 0) {
       return;
     }
@@ -701,58 +700,68 @@ public class ParticleSystem {
     for (ParticleGroup group = m_groupList; group != null; group = group.getNext()) {
       m_allGroupFlags |= group.m_groupFlags;
     }
-    final float gravityx = step.dt * m_gravityScale * m_world.getGravity().x;
-    final float gravityy = step.dt * m_gravityScale * m_world.getGravity().y;
-    float criticalVelocytySquared = getCriticalVelocitySquared(step);
-    for (int i = 0; i < m_count; i++) {
-      Vec2 v = m_velocityBuffer.data[i];
-      v.x += gravityx;
-      v.y += gravityy;
-      float v2 = v.x * v.x + v.y * v.y;
-      if (v2 > criticalVelocytySquared) {
-        float a = v2 == 0 ? Float.MAX_VALUE : MathUtils.sqrt(criticalVelocytySquared / v2);
-        v.x *= a;
-        v.y *= a;
+
+    // this lives outside the loop here to use less memory
+    TimeStep subStep = step.clone();
+    subStep.dt /= step.particleIterations;
+    subStep.inv_dt *= step.particleIterations;
+
+    for (int iterationIndex = 0; iterationIndex < step.particleIterations; iterationIndex++) {
+      ++m_timestamp;
+
+      final float gravityx = subStep.dt * m_gravityScale * m_world.getGravity().x;
+      final float gravityy = subStep.dt * m_gravityScale * m_world.getGravity().y;
+      float criticalVelocytySquared = getCriticalVelocitySquared(subStep);
+      for (int i = 0; i < m_count; i++) {
+        Vec2 v = m_velocityBuffer.data[i];
+        v.x += gravityx;
+        v.y += gravityy;
+        float v2 = v.x * v.x + v.y * v.y;
+        if (v2 > criticalVelocytySquared) {
+          float a = v2 == 0 ? Float.MAX_VALUE : MathUtils.sqrt(criticalVelocytySquared / v2);
+          v.x *= a;
+          v.y *= a;
+        }
       }
+      solveCollision(subStep);
+      if ((m_allGroupFlags & ParticleGroupType.b2_rigidParticleGroup) != 0) {
+        solveRigid(subStep);
+      }
+      if ((m_allParticleFlags & ParticleType.b2_wallParticle) != 0) {
+        solveWall(subStep);
+      }
+      for (int i = 0; i < m_count; i++) {
+        Vec2 pos = m_positionBuffer.data[i];
+        Vec2 vel = m_velocityBuffer.data[i];
+        pos.x += subStep.dt * vel.x;
+        pos.y += subStep.dt * vel.y;
+      }
+      updateBodyContacts();
+      updateContacts(false);
+      if ((m_allParticleFlags & ParticleType.b2_viscousParticle) != 0) {
+        solveViscous(subStep);
+      }
+      if ((m_allParticleFlags & ParticleType.b2_powderParticle) != 0) {
+        solvePowder(subStep);
+      }
+      if ((m_allParticleFlags & ParticleType.b2_tensileParticle) != 0) {
+        solveTensile(subStep);
+      }
+      if ((m_allParticleFlags & ParticleType.b2_elasticParticle) != 0) {
+        solveElastic(subStep);
+      }
+      if ((m_allParticleFlags & ParticleType.b2_springParticle) != 0) {
+        solveSpring(subStep);
+      }
+      if ((m_allGroupFlags & ParticleGroupType.b2_solidParticleGroup) != 0) {
+        solveSolid(subStep);
+      }
+      if ((m_allParticleFlags & ParticleType.b2_colorMixingParticle) != 0) {
+        solveColorMixing(subStep);
+      }
+      solvePressure(subStep);
+      solveDamping(subStep);
     }
-    solveCollision(step);
-    if ((m_allGroupFlags & ParticleGroupType.b2_rigidParticleGroup) != 0) {
-      solveRigid(step);
-    }
-    if ((m_allParticleFlags & ParticleType.b2_wallParticle) != 0) {
-      solveWall(step);
-    }
-    for (int i = 0; i < m_count; i++) {
-      Vec2 pos = m_positionBuffer.data[i];
-      Vec2 vel = m_velocityBuffer.data[i];
-      pos.x += step.dt * vel.x;
-      pos.y += step.dt * vel.y;
-    }
-    updateBodyContacts();
-    updateContacts(false);
-    if ((m_allParticleFlags & ParticleType.b2_viscousParticle) != 0) {
-      solveViscous(step);
-    }
-    if ((m_allParticleFlags & ParticleType.b2_powderParticle) != 0) {
-      solvePowder(step);
-    }
-    if ((m_allParticleFlags & ParticleType.b2_tensileParticle) != 0) {
-      solveTensile(step);
-    }
-    if ((m_allParticleFlags & ParticleType.b2_elasticParticle) != 0) {
-      solveElastic(step);
-    }
-    if ((m_allParticleFlags & ParticleType.b2_springParticle) != 0) {
-      solveSpring(step);
-    }
-    if ((m_allGroupFlags & ParticleGroupType.b2_solidParticleGroup) != 0) {
-      solveSolid(step);
-    }
-    if ((m_allParticleFlags & ParticleType.b2_colorMixingParticle) != 0) {
-      solveColorMixing(step);
-    }
-    solvePressure(step);
-    solveDamping(step);
   }
 
   void solvePressure(TimeStep step) {


### PR DESCRIPTION
This takes the code from the C++ particle solver that handles iterations and ports it to Java. It works in the cases that we are using it in, but I haven't tested it very broadly. It seems to follow the C++ code pretty closely, however.